### PR TITLE
Update version in installation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Sample Tarball installation
 
 ```sh
 MODULE_NAME=reactbundle
-MODULE_VERSION=v0.6.0
+MODULE_VERSION=v0.7.0
 MODULES_PATH="/usr/share/icingaweb2/modules"
 MODULE_PATH="${MODULES_PATH}/${MODULE_NAME}"
 RELEASES="https://github.com/Icinga/icingaweb2-module-${MODULE_NAME}/archive"
@@ -28,7 +28,7 @@ Sample GIT installation
 
 ```sh
 MODULE_NAME=reactbundle
-MODULE_VERSION=v0.6.0
+MODULE_VERSION=v0.7.0
 REPO="https://github.com/Icinga/icingaweb2-module-${MODULE_NAME}"
 MODULES_PATH="/usr/share/icingaweb2/modules"
 git clone ${REPO} "${MODULES_PATH}/${MODULE_NAME}" --branch "${MODULE_VERSION}"
@@ -48,4 +48,4 @@ Developer Documentation
 
 e.g.
 
-    ./bin/make-release.sh 0.6.0
+    ./bin/make-release.sh 0.7.0


### PR DESCRIPTION
The example installation instructions don't install the latest version. I was getting the same error as https://github.com/Icinga/icingaweb2-module-reactbundle/issues/8 when setting up Director because Director requires >=0.7.0, so I believe this should fix that issue too.